### PR TITLE
Gatsby: Fix styled components plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,5 +4,5 @@ module.exports = {
     description: `Kick off your next, great prototype with this G2 starter.`,
     author: `@itsjonq`,
   },
-  plugins: [`@wp-g2/gatsby-plugin-styles`, `gatsby-plugin-react-helmet`, `gatsby-plugin-styled-components`],
+  plugins: [`@wp-g2/gatsby-plugin-styles`, `gatsby-plugin-react-helmet`],
 }


### PR DESCRIPTION
This update removes the gatsby-plugin-styled-components plugin. It doesn't seem to be used 🤔 .
It was also causing npm start issues as it wasn't included as a dependency in the package.json.

Hope this helps!